### PR TITLE
flutter create: don't use relative paths in IDEA config files (#9414)

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -192,7 +192,6 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
       String projectDescription, String dirPath, String flutterRoot,
       { bool renderDriverTest: false, bool withPluginHook: false }) {
     flutterRoot = fs.path.normalize(flutterRoot);
-    flutterRoot = _relativePath(from: dirPath, to: flutterRoot);
 
     final String pluginDartClass = _createPluginClassName(projectName);
     final String pluginClass = pluginDartClass.endsWith('Plugin')
@@ -205,7 +204,6 @@ Host platform code is in the android/ and ios/ directories under $relativePlugin
       'iosIdentifier': _createUTIIdentifier(projectName),
       'description': projectDescription,
       'dartSdk': '$flutterRoot/bin/cache/dart-sdk',
-      'flutterPackagesDirectory': fs.path.join(flutterRoot, 'packages'),
       'androidMinApiLevel': android.minApiLevel,
       'androidSdkVersion': android_sdk.minimumAndroidSdkVersion,
       'androidFlutterJar': "$flutterRoot/bin/cache/artifacts/engine/android-arm/flutter.jar",
@@ -299,12 +297,4 @@ String _validateProjectDir(String dirPath, { String flutterRoot }) {
   }
 
   return null;
-}
-
-String _relativePath({ String from, String to }) {
-  final String result = fs.path.relative(to, from: from);
-  // `fs.path.relative()` doesn't always return a correct result: dart-lang/path#12.
-  if (fs.isDirectorySync(fs.path.join(from, result)))
-    return result;
-  return to;
 }


### PR DESCRIPTION
When invoked from the command line, relative paths aren't typically
used, but they are when invoked from within IDEA and prevents
IDEA from reading the files.

Also, remove flutterPackagesDirectory since it's not used